### PR TITLE
Allow global middlewares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# IDEs
+.idea
+
+# composer
+/vendor/*
+
+# phpunit
+.phpunit*

--- a/Mezon/Router/UrlParser.php
+++ b/Mezon/Router/UrlParser.php
@@ -280,11 +280,19 @@ trait UrlParser
      */
     private function getMiddlewareResult(string $route): array
     {
-        $middleWares = $this->middleware[$this->calledRoute] ?? null;
+        $middleWares = [];
+
+        if (isset($this->middleware['*'])) {
+            $middleWares = $this->middleware['*'];
+        }
+
+        if ($this->calledRoute !== '*' && isset($this->middleware[$this->calledRoute])) {
+            $middleWares = array_merge($middleWares, $this->middleware[$this->calledRoute]);
+        }
 
         $result = [$route, $this->parameters];
 
-        if (!isset($middleWares)) {
+        if (!count($middleWares)) {
             return $result;
         }
 


### PR DESCRIPTION
Another nice addition to this project I think would be the possibility to the user to apply some middlewares to every route available, whith this the user could:
- Make some validations to every route or group or routes
- Treat the data before passing the parameters to the callback

And definetlly expand the possibilities of usage

Features:
- Add multiple middlewares to every route
- The global routes will be applied before the route specific middlewares